### PR TITLE
Switch to maintained fork for `maybe-async-cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ defmt = { version = "0.3", optional = true }
 embedded-hal = { version = "1.0", optional = true }
 embedded-hal-async = { version = "1.0", optional = true }
 log = { version = "0.4", optional = true }
-maybe-async-cfg = "0.2"
+maybe-async-cfg2 = "0.3"
 
 [features]
 async = ["dep:embedded-hal-async"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ impl From<u8> for Status {
 }
 
 /// A DS4432 Digital To Analog (DAC) converter on the I2C bus `I`.
-#[maybe_async_cfg::maybe(
+#[maybe_async_cfg2::maybe(
     sync(feature = "sync", self = "DS4432"),
     async(feature = "async", keep_self)
 )]
@@ -141,7 +141,7 @@ pub struct AsyncDS4432<I> {
     rfs1_ohm: Option<u32>,
 }
 
-#[maybe_async_cfg::maybe(
+#[maybe_async_cfg2::maybe(
     sync(
         feature = "sync",
         self = "DS4432",


### PR DESCRIPTION
I forked `maybe-async-cfg` (which itself is a fork of `maybe-async`), cleaned up the docs a bit, and published it at `maybe-async-cfg2`

https://crates.io/crates/maybe-async-cfg2